### PR TITLE
Hotfix: signupGap update fails

### DIFF
--- a/app/server/methods/courses.js
+++ b/app/server/methods/courses.js
@@ -115,7 +115,7 @@ Meteor.methods({
     var validSettings = _.pick(settings, validFields);
 
     var course = Courses.findOne({name: courseName});
-    var currentSettings = course.settings;
+    var currentSettings = course.settings || {};
     var newSettings = _.extend(currentSettings, validSettings);
 
     console.log("Updating " + courseName + " settings with " + JSON.stringify(validSettings));


### PR DESCRIPTION
The server side method `updateCourseSettings` was failing when an existing course didn't have the `settings` property. This fixes that.