### PR TITLE
Hotfix: Fix signup gap reference

### DIFF
--- a/app/client/components/queueList/signupGap.js
+++ b/app/client/components/queueList/signupGap.js
@@ -5,7 +5,9 @@ Template.signupGap.onCreated(function() {
 
   self.autorun(function() {
     // Reactively update signupGap
-    var signupGap = Courses.findOne({name: Template.currentData().course}).settings.signupGap || 0
+    debugger;
+    var courseSettings = Courses.findOne({name: Template.currentData().course}).settings || {};
+    var signupGap = courseSettings.signupGap || 0
     self.signupGap.set(signupGap);
 
     // Reactively update the timeRemaining for user to sign up again

--- a/app/lib/signupGap.js
+++ b/app/lib/signupGap.js
@@ -34,6 +34,7 @@ _nextSignupTime = function(userId, queueId) {
     return null;
 
   // Otherwise, calculate the next possible signup time.
-  var signupGap = Courses.findOne({name: queue.course}).settings.signupGap || 0;
+  var courseSettings = Courses.findOne({name: queue.course}).settings || {};
+  var signupGap = courseSettings.signupGap || 0;
   return lastUsedTicket.doneAt + signupGap;
 }


### PR DESCRIPTION
Clients crash when course settings aren't defined, because of a broken reference to `signupGap`.