### PR TITLE
Fix #22: Use Collection2, define schemas, and setup migration

### DIFF
--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -36,3 +36,4 @@ email
 kadira:debug
 meteorhacks:kadira
 pfafman:filesaver
+aldeed:collection2

--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -37,3 +37,4 @@ kadira:debug
 meteorhacks:kadira
 pfafman:filesaver
 aldeed:collection2
+percolate:migrations

--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -2,6 +2,11 @@ accounts-base@1.2.2
 accounts-password@1.1.4
 accounts-ui@1.1.6
 accounts-ui-unstyled@1.1.8
+aldeed:collection2@2.8.0
+aldeed:collection2-core@1.0.0
+aldeed:schema-deny@1.0.1
+aldeed:schema-index@1.0.1
+aldeed:simple-schema@1.5.3
 athyuttamre:accounts-saml2@0.0.3
 autoupdate@1.2.4
 babel-compiler@5.8.24_1
@@ -50,6 +55,7 @@ less@2.5.1
 livedata@1.0.15
 localstorage@1.0.5
 logging@1.0.8
+mdg:validation-error@0.2.0
 meteor@1.1.10
 meteor-base@1.0.1
 meteorhacks:kadira@2.23.4
@@ -72,6 +78,7 @@ ordered-dict@1.0.4
 percolate:synced-cron@1.3.0
 pfafman:filesaver@0.2.2
 promise@0.5.1
+raix:eventemitter@0.1.3
 random@1.0.5
 rate-limit@1.0.0
 reactive-dict@1.1.3

--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -75,6 +75,7 @@ npm-bcrypt@0.7.8_2
 npm-mongo@1.4.39_1
 observe-sequence@1.0.7
 ordered-dict@1.0.4
+percolate:migrations@0.9.8
 percolate:synced-cron@1.3.0
 pfafman:filesaver@0.2.2
 promise@0.5.1

--- a/app/client/components/queueList/signupGap.js
+++ b/app/client/components/queueList/signupGap.js
@@ -5,7 +5,6 @@ Template.signupGap.onCreated(function() {
 
   self.autorun(function() {
     // Reactively update signupGap
-    debugger;
     var courseSettings = Courses.findOne({name: Template.currentData().course}).settings || {};
     var signupGap = courseSettings.signupGap || 0
     self.signupGap.set(signupGap);

--- a/app/collections/announcements.js
+++ b/app/collections/announcements.js
@@ -1,34 +1,15 @@
 Announcements = new Mongo.Collection("announcements");
 
 Announcements.schema = new SimpleSchema({
-  owner: {
-    type: Object
-  },
-  "owner.id": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Id
-  },
-  "owner.email": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Email
-  },
+  owner: {type: Object},
+  "owner.id": {type: String, regEx: SimpleSchema.RegEx.Id},
+  "owner.email": {type: String, regEx: SimpleSchema.RegEx.Email},
 
-  type: {
-    type: String,
-    allowedValues: ["info", "success", "warning", "danger"]
-  },
+  type: {type: String, allowedValues: ["info", "success", "warning", "danger"]},
+  header: {type: String, optional: true},
+  content: {type: String},
 
-  header: {
-    type: String,
-    optional: true
-  },
-  content: {
-    type: String
-  },
-
-  createdAt: {
-    type: Date
-  }
+  createdAt: {type: Date}
 });
 
 Announcements.attachSchema(Announcements.schema);

--- a/app/collections/announcements.js
+++ b/app/collections/announcements.js
@@ -1,19 +1,33 @@
-/**
- * Announcements
- *
- * Announcement: {
- *    owner: {
- *      id: userId,
- *      name: STRING,
- *    },
- *    type: ("info", "success", "warning", "danger"),
- *    header: STRING,
- *    content: STRING,
- *    createdAt: Number (Milliseconds)
- *  }
- */
-
 Announcements = new Mongo.Collection("announcements");
+
+Announcements.schema = new SimpleSchema({
+  "owner.id": {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id
+  },
+  "owner.email": {
+    type: String,
+    regEx: SimpleSchema.RegEx.Email
+  },
+  type: {
+    type: String,
+    allowedValues: ["info", "success", "warning", "danger"]
+  },
+
+  header: {
+    type: String,
+    optional: true
+  },
+  content: {
+    type: String
+  },
+
+  createdAt: {
+    type: Date
+  }
+});
+
+Announcements.attachSchema(Announcements.schema);
 
 Announcements.allow({
   insert: function() { return false; },

--- a/app/collections/announcements.js
+++ b/app/collections/announcements.js
@@ -1,6 +1,9 @@
 Announcements = new Mongo.Collection("announcements");
 
 Announcements.schema = new SimpleSchema({
+  owner: {
+    type: Object
+  }
   "owner.id": {
     type: String,
     regEx: SimpleSchema.RegEx.Id
@@ -9,6 +12,7 @@ Announcements.schema = new SimpleSchema({
     type: String,
     regEx: SimpleSchema.RegEx.Email
   },
+
   type: {
     type: String,
     allowedValues: ["info", "success", "warning", "danger"]

--- a/app/collections/announcements.js
+++ b/app/collections/announcements.js
@@ -3,7 +3,7 @@ Announcements = new Mongo.Collection("announcements");
 Announcements.schema = new SimpleSchema({
   owner: {
     type: Object
-  }
+  },
   "owner.id": {
     type: String,
     regEx: SimpleSchema.RegEx.Id

--- a/app/collections/courses.js
+++ b/app/collections/courses.js
@@ -1,23 +1,39 @@
-/**
- * Courses
- *
- * Course: {
- *    name: STRING,
- *    description: STRING,
- *    listserv: STRING,
- *    active: BOOLEAN,
- *
- *    htas: [userId],
- *    tas: [userId],
- *
- *    settings: {
- *      
- *    },
- *    createdAt: Number (Milliseconds)
- * }
- */
-
 Courses = new Mongo.Collection("courses");
+
+Courses.schema = new SimpleSchema({
+  name: {
+    type: String
+  },
+  description: {
+    type: String,
+    optional: true
+  },
+  listserv: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Email,
+    optional: true
+  },
+  active: {
+    type: Boolean
+  },
+
+  htas: {
+    type: [String],
+    regEx: SimpleSchema.RegEx.Id,
+    optional: true
+  },
+  tas: {
+    type: [String],
+    regEx: SimpleSchema.RegEx.Id,
+    optional: true
+  },
+
+  createdAt: {
+    type: Date
+  }
+});
+
+Courses.attachSchema(Courses.schema);
 
 Courses.allow({
   insert: function() { return false; },

--- a/app/collections/courses.js
+++ b/app/collections/courses.js
@@ -1,36 +1,15 @@
 Courses = new Mongo.Collection("courses");
 
 Courses.schema = new SimpleSchema({
-  name: {
-    type: String
-  },
-  description: {
-    type: String,
-    optional: true
-  },
-  listserv: {
-    type: String,
-    regEx: SimpleSchema.RegEx.Email,
-    optional: true
-  },
-  active: {
-    type: Boolean
-  },
+  name: {type: String},
+  description: {type: String, optional: true},
+  listserv: {type: String, regEx: SimpleSchema.RegEx.Email, optional: true},
+  active: {type: Boolean},
 
-  htas: {
-    type: [String],
-    regEx: SimpleSchema.RegEx.Id,
-    optional: true
-  },
-  tas: {
-    type: [String],
-    regEx: SimpleSchema.RegEx.Id,
-    optional: true
-  },
+  htas: {type: [String], regEx: SimpleSchema.RegEx.Id, optional: true},
+  tas: {type: [String], regEx: SimpleSchema.RegEx.Id, optional: true},
 
-  createdAt: {
-    type: Date
-  }
+  createdAt: {type: Number}
 });
 
 Courses.attachSchema(Courses.schema);

--- a/app/collections/courses.js
+++ b/app/collections/courses.js
@@ -9,6 +9,9 @@ Courses.schema = new SimpleSchema({
   htas: {type: [String], regEx: SimpleSchema.RegEx.Id, optional: true},
   tas: {type: [String], regEx: SimpleSchema.RegEx.Id, optional: true},
 
+  settings: {type: Object, optional: true},
+  "settings.signupGap": {type: Number, defaultValue: 0, optional: true},
+
   createdAt: {type: Number}
 });
 

--- a/app/collections/locations.js
+++ b/app/collections/locations.js
@@ -1,15 +1,7 @@
 Locations = new Mongo.Collection("locations");
 
 Locations.schema = new SimpleSchema({
-  name: {
-    type: String
-  },
-
-  ips: {
-    type: [String],
-    regEx: SimpleSchema.RegEx.IP,
-    optional: true
-  }
+  name: {type: String}
 });
 
 Locations.allow({

--- a/app/collections/locations.js
+++ b/app/collections/locations.js
@@ -1,18 +1,16 @@
-/**
- * Locations
- *
- * Location:  {
- *    name: STRING,
- *    
- *    ips: [STRING],
- *    geo: {
- *      root: GeoJSON,
- *      radius: Number (Meters)
- *    }
- * }
- */
-
 Locations = new Mongo.Collection("locations");
+
+Locations.schema = new SimpleSchema({
+  name: {
+    type: String
+  },
+
+  ips: {
+    type: [String],
+    regEx: SimpleSchema.RegEx.IP,
+    optional: true
+  }
+});
 
 Locations.allow({
   insert: function() { return false; },

--- a/app/collections/queues.js
+++ b/app/collections/queues.js
@@ -48,7 +48,7 @@ Queues.schema = new SimpleSchema({
   location: {
     type: Object,
     optional: true
-  }
+  },
   "location.id": {
     type: String,
     regEx: SimpleSchema.RegEx.Id,

--- a/app/collections/queues.js
+++ b/app/collections/queues.js
@@ -1,32 +1,3 @@
-/**
- * Queues
- *
- * Queue: {
- *    name: STRING,
- *    course: STRING,
- *    location: ObjectId,
- *    mode: ("universal", "location", "device") // TODO: Expand this
- *
- *    status: STRING ("active", "cutoff", "ended"),
- *    owner: {
- *      id: userId,
- *      email: STRING
- *    },
- *    
- *    startTime: Number (Milliseconds),
- *    cutoffTime: Number (Milliseconds),
- *    endTime: Number (Milliseconds),
- *    averageWaitTime: Number (Milliseconds),
- *
- *    localSettings: {
- *      property: value (Overrides from Course)
- *    },
- *    
- *    announcements: [],
- *    tickets: []
- * }
- */
-
 Queues = new Mongo.Collection("queues");
 
 Queues.schema = new SimpleSchema({

--- a/app/collections/queues.js
+++ b/app/collections/queues.js
@@ -1,88 +1,22 @@
 Queues = new Mongo.Collection("queues");
 
 Queues.schema = new SimpleSchema({
-  name: {
-    type: String
-  },
+  name: {type: String},
+  course: {type: String},
+  location: {type: String, regEx: SimpleSchema.RegEx.Id, optional: true},
+  status: {type: String, allowedValues: ["active", "cutoff", "ended"]},
 
-  course: {
-    type: Object
-  },
-  "course.id": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Id
-  },
-  "course.name": {
-    type: String
-  },
+  owner: {type: Object},
+  "owner.id": {type: String, regEx: SimpleSchema.RegEx.Id},
+  "owner.email": {type: String, regEx: SimpleSchema.RegEx.Email},
 
-  location: {
-    type: Object,
-    optional: true
-  },
-  "location.id": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Id,
-    optional: true
-  },
-  "location.name": {
-    type: String,
-    optional: true
-  },
+  announcements: {type: [String], regEx: SimpleSchema.RegEx.Id, optional: true},
+  tickets: {type: [String], regEx: SimpleSchema.RegEx.Id, defaultValue: []},
 
-  mode: {
-    type: String,
-    allowedValues: ["universal", "location", "device"]
-  },
-
-  status: {
-    type: String,
-    allowedValues: ["active", "cutoff", "ended"]
-  },
-
-  owner: {
-    type: Object
-  },
-  "owner.id": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Id
-  },
-  "owner.email": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Email
-  },
-
-  announcements: {
-    type: [String],
-    regEx: SimpleSchema.RegEx.Id,
-    optional: true
-  },
-  tickets: {
-    type: [String],
-    regEx: SimpleSchema.RegEx.Id,
-    defaultValue: []
-  },
-
-  averageWaitTime: {
-    type: Number,
-    defaultValue: 0
-  },
-
-  startTime: {
-    type: Date
-  },
-  cutoffTime: {
-    type: Date,
-    optional: true
-  },
-  scheduledEndTime: {
-    type: Date,
-    optional: true
-  },
-  endTime: {
-    type: Date,
-    optional: true
-  }
+  startTime: {type: Number},
+  cutoffTime: {type: Number, optional: true},
+  endTime: {type: Number, optional: true},
+  averageWaitTime: {type: Number, defaultValue: 0}
 });
 
 Queues.attachSchema(Queues.schema);

--- a/app/collections/queues.js
+++ b/app/collections/queues.js
@@ -39,6 +39,10 @@ Queues.schema = new SimpleSchema({
     type: String,
     allowedValues: ["active", "cutoff", "ended"]
   },
+
+  owner: {
+    type: Object
+  },
   "owner.id": {
     type: String,
     regEx: SimpleSchema.RegEx.Id

--- a/app/collections/queues.js
+++ b/app/collections/queues.js
@@ -33,14 +33,32 @@ Queues.schema = new SimpleSchema({
   name: {
     type: String
   },
+
   course: {
+    type: Object
+  },
+  "course.id": {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id
+  },
+  "course.name": {
     type: String
   },
+
   location: {
+    type: Object,
+    optional: true
+  }
+  "location.id": {
     type: String,
     regEx: SimpleSchema.RegEx.Id,
     optional: true
   },
+  "location.name": {
+    type: String,
+    optional: true
+  },
+
   mode: {
     type: String,
     allowedValues: ["universal", "location", "device"]
@@ -59,22 +77,6 @@ Queues.schema = new SimpleSchema({
     regEx: SimpleSchema.RegEx.Email
   },
 
-  startedAt: {
-    type: Date
-  },
-  cutoffAt: {
-    type: Date,
-    optional: true
-  },
-  endedAt: {
-    type: Date,
-    optional: true
-  },
-  averageWaitTime: {
-    type: Number,
-    defaultValue: 0
-  },
-
   announcements: {
     type: [String],
     regEx: SimpleSchema.RegEx.Id,
@@ -84,6 +86,27 @@ Queues.schema = new SimpleSchema({
     type: [String],
     regEx: SimpleSchema.RegEx.Id,
     defaultValue: []
+  },
+
+  averageWaitTime: {
+    type: Number,
+    defaultValue: 0
+  },
+
+  startTime: {
+    type: Date
+  },
+  cutoffTime: {
+    type: Date,
+    optional: true
+  },
+  scheduledEndTime: {
+    type: Date,
+    optional: true
+  },
+  endTime: {
+    type: Date,
+    optional: true
   }
 });
 

--- a/app/collections/queues.js
+++ b/app/collections/queues.js
@@ -29,6 +29,66 @@
 
 Queues = new Mongo.Collection("queues");
 
+Queues.schema = new SimpleSchema({
+  name: {
+    type: String
+  },
+  course: {
+    type: String
+  },
+  location: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+    optional: true
+  },
+  mode: {
+    type: String,
+    allowedValues: ["universal", "location", "device"]
+  },
+
+  status: {
+    type: String,
+    allowedValues: ["active", "cutoff", "ended"]
+  },
+  "owner.id": {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id
+  },
+  "owner.email": {
+    type: String,
+    regEx: SimpleSchema.RegEx.Email
+  },
+
+  startedAt: {
+    type: Date
+  },
+  cutoffAt: {
+    type: Date,
+    optional: true
+  },
+  endedAt: {
+    type: Date,
+    optional: true
+  },
+  averageWaitTime: {
+    type: Number,
+    defaultValue: 0
+  },
+
+  announcements: {
+    type: [String],
+    regEx: SimpleSchema.RegEx.Id,
+    optional: true
+  },
+  tickets: {
+    type: [String],
+    regEx: SimpleSchema.RegEx.Id,
+    defaultValue: []
+  }
+});
+
+Queues.attachSchema(Queues.schema);
+
 Queues.allow({
   insert: function() { return false; },
   update: function() { return false; },

--- a/app/collections/tickets.js
+++ b/app/collections/tickets.js
@@ -8,7 +8,7 @@ Tickets.schema = new SimpleSchema({
   "owner.id": {type: String, regEx: SimpleSchema.RegEx.Id},
   "owner.name": {type: String},
 
-  status: {type: String, allowedValues: ["open", "missing", "done", "cancelled"]},
+  status: {type: String, allowedValues: ["open", "done", "cancelled"]},
   question: {type: String},
 
   notify: {type: Object, optional: true},

--- a/app/collections/tickets.js
+++ b/app/collections/tickets.js
@@ -1,112 +1,30 @@
-/**
- * Tickets
- *
- * Ticket: {
- *    queueId: STRING,
- *    course: STRING,
- *    owner: {
- *      id: userId,
- *      name: STRING,
- *    },
- *    status: ("open", "missing", "done", "cancelled"),
- *
- *    createdAt: Number (Milliseconds),
- *    missedAt: Number (Milliseconds),
- *    doneAt: Number (Milliseconds),
- *    cancelledAt: Number (Milliseconds),
- *
- *    question: STRING,
- *
- *    notify: {
- *      types: ["announce", "email", "text"],
- *      email: STRING,
- *      phone: STRING,
- *      carrier: STRING
- *    },
- *
- *    ta: {
- *      id: userId, // The TA who set the last status
- *      email: STRING
- *    }
- *
- *    flag: {
- *      flagged: Boolean,
- *      message: STRING,
- *      ta: {
- *        id: userId,
- *        email: STRING
- *      }
- *    }
- *  }
- */
-
 Tickets = new Mongo.Collection("tickets");
 
 Tickets.schema = new SimpleSchema({
-  course: {
-    type: Object
-  },
-  "course.id": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Id
-  },
-  "course.name": {
-    type: String
-  },
+  queueId: {type: String, regEx: SimpleSchema.RegEx.Id},
+  course: {type: String},
 
-  queueId: {
-    type: String,
-    regEx: SimpleSchema.RegEx.Id
-  },
+  owner: {type: Object},
+  "owner.id": {type: String, regEx: SimpleSchema.RegEx.Id},
+  "owner.name": {type: String},
 
-  status: {
-    type: String,
-    allowedValues: ["open", "missing", "done", "cancelled"]
-  },
+  status: {type: String, allowedValues: ["open", "missing", "done", "cancelled"]},
+  question: {type: String},
 
-  question: {
-    type: String
-  },
+  notify: {type: Object, optional: true},
+  "notify.types": {type: [String], allowedValues: ["announce", "email", "text"], minCount: 1},
+  "notify.email": {type: String, regEx: SimpleSchema.RegEx.Email, optional: true},
+  "notify.phone": {type: String, optional: true},
+  "notify.carrier": {type: String, regEx: SimpleSchema.RegEx.Domain, optional: true},
+  "notify.sent": {type: [String], allowedValues: ["email", "text"], optional: true}
 
-  notify: {
-    type: Object,
-    optional: true
-  },
-  "notify.types": {
-    type: [String],
-    allowedValues: ["announce", "email", "text"],
-    minLength: 1
-  },
-  "notify.email": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Email,
-    optional: true
-  },
-  "notify.phone": {
-    type: String,
-    optional: true
-  },
-  "notify.carrier": {
-    type: String,
-    regEx: SimpleSchema.RegEx.Domain,
-    optional: true
-  },
+  ta: {type: Object, optional: true},
+  "ta.id": {type: String, regEx: SimpleSchema.RegEx.Id},
+  "ta.email": {type: String, regEx: SimpleSchema.RegEx.Email},
 
-  createTime: {
-    type: Date
-  },
-  markedAsMissingTime: {
-    type: Date,
-    optional: true
-  },
-  markedAsDoneTime: {
-    type: Date,
-    optional: true
-  },
-  cancelTime: {
-    type: Date,
-    optional: true
-  }
+  createdAt: {type: Number},
+  doneAt: {type: Number, optional: true},
+  cancelledAt: {type: Number, optional: true}
 });
 
 Tickets.attachSchema(Tickets.schema);

--- a/app/collections/tickets.js
+++ b/app/collections/tickets.js
@@ -16,7 +16,7 @@ Tickets.schema = new SimpleSchema({
   "notify.email": {type: String, regEx: SimpleSchema.RegEx.Email, optional: true},
   "notify.phone": {type: String, optional: true},
   "notify.carrier": {type: String, regEx: SimpleSchema.RegEx.Domain, optional: true},
-  "notify.sent": {type: [String], allowedValues: ["email", "text"], optional: true}
+  "notify.sent": {type: [String], allowedValues: ["email", "text"], optional: true},
 
   ta: {type: Object, optional: true},
   "ta.id": {type: String, regEx: SimpleSchema.RegEx.Id},

--- a/app/collections/tickets.js
+++ b/app/collections/tickets.js
@@ -16,7 +16,7 @@
  *    cancelledAt: Number (Milliseconds),
  *
  *    question: STRING,
- *      
+ *
  *    notify: {
  *      types: ["announce", "email", "text"],
  *      email: STRING,
@@ -28,7 +28,7 @@
  *      id: userId, // The TA who set the last status
  *      email: STRING
  *    }
- *    
+ *
  *    flag: {
  *      flagged: Boolean,
  *      message: STRING,
@@ -41,6 +41,75 @@
  */
 
 Tickets = new Mongo.Collection("tickets");
+
+Tickets.schema = new SimpleSchema({
+  course: {
+    type: Object
+  },
+  "course.id": {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id
+  },
+  "course.name": {
+    type: String
+  },
+
+  queueId: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id
+  },
+
+  status: {
+    type: String,
+    allowedValues: ["open", "missing", "done", "cancelled"]
+  },
+
+  question: {
+    type: String
+  },
+
+  notify: {
+    type: Object,
+    optional: true
+  },
+  "notify.types": {
+    type: [String],
+    allowedValues: ["announce", "email", "text"],
+    minLength: 1
+  },
+  "notify.email": {
+    type: String,
+    regEx: SimpleSchema.RegEx.Email,
+    optional: true
+  },
+  "notify.phone": {
+    type: String,
+    optional: true
+  },
+  "notify.carrier": {
+    type: String,
+    regEx: SimpleSchema.RegEx.Domain,
+    optional: true
+  },
+
+  createTime: {
+    type: Date
+  },
+  markedAsMissingTime: {
+    type: Date,
+    optional: true
+  },
+  markedAsDoneTime: {
+    type: Date,
+    optional: true
+  },
+  cancelTime: {
+    type: Date,
+    optional: true
+  }
+});
+
+Tickets.attachSchema(Tickets.schema);
 
 Tickets.allow({
   insert: function() { return false; },

--- a/app/collections/users.js
+++ b/app/collections/users.js
@@ -1,6 +1,6 @@
-/**
- * Users
- */
+// Note: we don't specify a schema for users because that would force us to
+// account for every possible field. This is dangerous and hard to maintain
+// as we add more packages or as Meteor changes. Best to stay away for now.
 
 Meteor.users.allow({
   insert: function() { return false; },

--- a/app/lib/signupGap.js
+++ b/app/lib/signupGap.js
@@ -17,7 +17,7 @@ _nextSignupTime = function(userId, queueId) {
   if (userTickets.length == 0)
     return null;
 
-  var lastUsedTicket; // The last ticket that's open, missing, or done.
+  var lastUsedTicket; // The last ticket that's open or done.
   for (var i = userTickets.length - 1; i >= 0; i--) {
     var ticket = userTickets[i];
     if (ticket.status !== "cancelled") {
@@ -29,8 +29,8 @@ _nextSignupTime = function(userId, queueId) {
   // If only cancelled tickets exist, return null.
   if (typeof lastUsedTicket === "undefined") return null;
 
-  // If an open / missing ticket exists, return null.
-  if (_.contains(["open", "missing"], lastUsedTicket.status))
+  // If an open ticket exists, return null.
+  if (lastUsedTicket.status == "open")
     return null;
 
   // Otherwise, calculate the next possible signup time.

--- a/app/server/methods/courses.js
+++ b/app/server/methods/courses.js
@@ -16,7 +16,7 @@ Meteor.methods({
       description: description,
       listserv: listserv,
       active: false,
-      createdAt: (new Date()).toJSON()
+      createdAt: Date.now()
     });
   },
 

--- a/app/server/methods/courses.js
+++ b/app/server/methods/courses.js
@@ -15,7 +15,8 @@ Meteor.methods({
       name: name,
       description: description,
       listserv: listserv,
-      active: false
+      active: false,
+      createdAt: (new Date()).toJSON()
     });
   },
 

--- a/app/server/methods/queues.js
+++ b/app/server/methods/queues.js
@@ -24,8 +24,9 @@ Meteor.methods({
     if(endTime <= Date.now())
       throw new Meteor.Error("invalid-end-time");
 
-    if(clientCall)
-      ownerId = Meteor.userId;
+    if(clientCall) {
+      ownerId = Meteor.userId();
+    }
 
     // Create queue
     var queue = {

--- a/app/server/methods/queues.js
+++ b/app/server/methods/queues.js
@@ -33,7 +33,6 @@ Meteor.methods({
       name: name,
       course: course,
       location: locationId,
-      mode: "universal",
 
       status: "active",
       owner: {
@@ -45,7 +44,6 @@ Meteor.methods({
       endTime: endTime,
       averageWaitTime: 0,
 
-      localSettings: {},
       announcements: [],
       tickets: []
     }
@@ -89,7 +87,7 @@ Meteor.methods({
 
     Queues.update(queueId, {
       $set: {
-        name: name, 
+        name: name,
         location: locationId,
         endTime: endTime
       }
@@ -203,7 +201,7 @@ Meteor.methods({
     console.log("Ending queue " + queueId);
 
     // TODO: Cancel active tickets?
-    
+
     SyncedCron.remove(queueId + "-ender");
 
     Queues.update(queueId, {

--- a/app/server/methods/tickets.js
+++ b/app/server/methods/tickets.js
@@ -47,10 +47,7 @@ Meteor.methods({
       status: "open",
 
       question: question,
-      notify: notify,
-
-      ta: {},
-      flag: {}
+      notify: notify
     }
 
     var ticketId = Tickets.insert(ticket);
@@ -114,14 +111,18 @@ Meteor.methods({
           email: _getUserEmail(this.userId)
         }
       }
+
+      var setObject = {
+        status: "cancelled",
+        cancelledAt: Date.now()
+      };
+      if(!_.isEmpty(taObject))
+        _.extend(setObject, taObject);
+
       Tickets.update({
         _id: ticketId
       }, {
-        $set: {
-          status: "cancelled",
-          cancelledAt: Date.now(),
-          ta: taObject
-        }
+        $set: setObject
       });
     }
   }

--- a/app/server/migrations/1.js
+++ b/app/server/migrations/1.js
@@ -6,14 +6,18 @@ Migrations.add({
       Courses.update(course._id, {$set: {createdAt: 0}});
     });
 
+    // Note: we use {validate: false} here because of a bug in collection2.
+    // At this point, it does not let you $unset fields that are not in the
+    // schema. More details here: https://github.com/aldeed/meteor-simple-schema/issues/519
+
     // Locations: remove 'ips' and 'geo' from all locations
-    Locations.update({}, {$unset: {ips: "", geo: ""}}, {multi: true});
+    Locations.update({}, {$unset: {ips: "", geo: ""}}, {multi: true, validate: false});
 
     // Queues: remove 'mode' and 'localSettings' from all queues
-    Queues.update({}, {$unset: {mode: "", localSettings: ""}}, {multi: true});
+    Queues.update({}, {$unset: {mode: "", localSettings: ""}}, {multi: true, validate: false});
 
     // Tickets: remove 'missedAt' and 'flag'
-    Tickets.update({}, {$unset: {missedAt: "", flag: ""}}, {multi: true});
+    Tickets.update({}, {$unset: {missedAt: "", flag: ""}}, {multi: true, validate: false});
 
   },
   down: function() {

--- a/app/server/migrations/1.js
+++ b/app/server/migrations/1.js
@@ -1,0 +1,24 @@
+Migrations.add({
+  version: 1,
+  up: function() {
+    // Courses: add 'createdAt' for courses without a creation time
+    Courses.find({createdAt: {$exists: false}}).forEach(function(course) {
+      Courses.update(course._id, {$set: {createdAt: 0}});
+    });
+
+    // Locations: remove 'ips' and 'geo' from all locations
+    Locations.update({}, {$unset: {ips: "", geo: ""}}, {multi: true});
+
+    // Queues: remove 'mode' and 'localSettings' from all queues
+    Queues.update({}, {$unset: {mode: "", localSettings: ""}}, {multi: true});
+
+    // Tickets: remove 'missedAt' and 'flag'
+    Tickets.update({}, {$unset: {missedAt: "", flag: ""}}, {multi: true});
+
+  },
+  down: function() {
+    Locations.update({}, {$set: {ips: [], geo: {}}}, {multi: true});
+    Queues.update({}, {$set: {mode: "universal", localSettings: {}}}, {multi: true});
+    Tickets.update({}, {$set: {missedAt: 0, flag: {}}}, {multi: true});
+  }
+});

--- a/app/server/publications/tickets.js
+++ b/app/server/publications/tickets.js
@@ -20,7 +20,6 @@ Meteor.smartPublish("allActiveTickets", function() {
         question: isTA,
         notify: isTA,
         ta: isTA,
-        flag: isTA,
         "notify.email": false,
         "notify.phone": false,
         "notify.carrier": false
@@ -55,8 +54,7 @@ Meteor.publish("allQueueTickets", function(queueId) {
     _.extend(projection["fields"], {
       question: false,
       notify: false,
-      ta: false,
-      flag: false
+      ta: false
     });
   }
 

--- a/app/server/publications/tickets.js
+++ b/app/server/publications/tickets.js
@@ -14,7 +14,7 @@ Meteor.smartPublish("allActiveTickets", function() {
 
     var tickets = Tickets.find({
       queueId: queueId,
-      status: {$in: ["open", "missing"]}
+      status: "open"
     }, {
       "fields": {
         question: isTA,

--- a/app/server/startup.js
+++ b/app/server/startup.js
@@ -3,6 +3,9 @@
 Meteor.startup(function() {
   console.log("Running SignMeUp");
 
+  // Update schemas
+  Migrations.migrateTo("latest");
+
   // Initialize Data
   createTestUsers();
   initializeCollections();


### PR DESCRIPTION
Key changes:

- We're using `collection2` to define schemas for our collections.
- Removed unused fields from the schemas.
- Write a migration using `percolate:migrations` to this new schema.
- Update methods and helpers that used the old fields.