### PR TITLE
Fix #60: Checkout latest tag on prod, show version in app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,8 @@ Once you've merged a bunch of features into `dev`, and are ready to deploy to pr
    To deploy, run `make prod`.
 
    This will:
-    - Pull the latest version of `master` from the Git repo
+    - Pull the latest release on `master` from GitHub
+    - Load the release version into an environment variable
     - Load `settings.json` into an environment variable
     - Build an image for the new codebase
     - Run it with production settings

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@
 # Builds and runs the app with prod settings.
 # Does not affect other running services. Use when you've changed just the app.
 prod:
-	git pull && \
+	git fetch --tags && \
+	git checkout master && \
+	version=$(git describe --tags) && \
+	git checkout ${version} && \
+	export VERSION=${version} && \
 	export METEOR_SETTINGS='$(shell cat ./app/settings.json)' && \
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml build app && \
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --no-deps -d app
@@ -21,7 +25,11 @@ prod:
 # Builds and runs all services with prod settings.
 # Use when you've updated the nginx or mongo configuration too.
 prod-all:
-	git pull && \
+	git fetch --tags && \
+	git checkout master && \
+	version=$(git describe --tags) && \
+	git checkout ${version} && \
+	export VERSION=${version} && \
 	export METEOR_SETTINGS='$(shell cat ./app/settings.json)' && \
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml build && \
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,8 @@
 prod:
 	git fetch --tags && \
 	git checkout master && \
-	version=$(git describe --tags) && \
-	git checkout ${version} && \
-	export VERSION=${version} && \
+	export VERSION='$(shell git describe --tags)' && \
+	git checkout $$VERSION && \
 	export METEOR_SETTINGS='$(shell cat ./app/settings.json)' && \
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml build app && \
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --no-deps -d app
@@ -27,9 +26,8 @@ prod:
 prod-all:
 	git fetch --tags && \
 	git checkout master && \
-	version=$(git describe --tags) && \
-	git checkout ${version} && \
-	export VERSION=${version} && \
+	export VERSION='$(shell git describe --tags)' && \
+	git checkout $$VERSION && \
 	export METEOR_SETTINGS='$(shell cat ./app/settings.json)' && \
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml build && \
 	docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d

--- a/app/client/components/footer/footer.html
+++ b/app/client/components/footer/footer.html
@@ -1,9 +1,9 @@
 <template name="footer">
   <footer>
     <div class="ui horizontal link list">
-      <a class="item disabled">SignMeUp</a>
-      <a href="https://github.com/athyuttamre/signmeup/wiki" class="item">Wiki</a>
-      <a href="https://github.com/athyuttamre/signmeup/issues/new" class="item">Report an Issue</a>
+      <a class="item disabled">SignMeUp {{version}}</a>
+      <a href="https://github.com/signmeup/signmeup/wiki" class="item">Wiki</a>
+      <a href="https://github.com/signmeup/signmeup/issues/new" class="item">Report an Issue</a>
       <a href="mailto:signmeup-dev@lists.cs.brown.edu" class="item">Contact</a>
     </div>
   </footer>

--- a/app/client/components/footer/footer.js
+++ b/app/client/components/footer/footer.js
@@ -1,0 +1,5 @@
+Template.footer.helpers({
+  version: function() {
+    return Meteor.settings.public.version;
+  }
+});

--- a/app/server/startup.js
+++ b/app/server/startup.js
@@ -1,12 +1,15 @@
 // Startup
 
 Meteor.startup(function() {
-  console.log("Running SignMeUp");
+  // Set version so client-side app can access it
+  var version = process.env.VERSION || "";
+  Meteor.settings.public.version = version
+  console.log("Running SignMeUp " + version);
 
   // Update schemas
   Migrations.migrateTo("latest");
 
-  // Initialize Data
+  // Initialize data
   createTestUsers();
   initializeCollections();
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,7 @@ app:
   dockerfile: Dockerfile-prod
   restart: always
   environment:
+   - VERSION=${VERSION}
    - ROOT_URL=https://signmeup.cs.brown.edu
    - MONGO_URL=mongodb://db:27017/signmeup
    - VIRTUAL_HOST=signmeup.cs.brown.edu


### PR DESCRIPTION
Modified the `Makefile` to pull the latest tag on `master` when building. In addition, we set an environment variable `VERSION` that the app uses to show the version client-side.