### PR TITLE
Hotfix: Filter phone numbers to accept only digits

### DIFF
--- a/app/imports/ui/components/modals/modal-join-queue/modal-join-queue.js
+++ b/app/imports/ui/components/modals/modal-join-queue/modal-join-queue.js
@@ -253,7 +253,7 @@ Template.ModalJoinQueue.events({
         errors = true;
       }
 
-      if (!number && number.length === 10) {
+      if (!number.length === 10) {
         Template.instance().errors.set('number', 'Please enter a valid phone number.');
         errors = true;
       }

--- a/app/imports/ui/components/modals/modal-join-queue/modal-join-queue.js
+++ b/app/imports/ui/components/modals/modal-join-queue/modal-join-queue.js
@@ -246,14 +246,14 @@ Template.ModalJoinQueue.events({
 
     if (event.target.textCheckbox.checked) {
       const carrier = event.target.carrier.value;
-      const number = event.target.number.value;
+      const number = event.target.number.value.replace(/\D+/g, '');
 
       if (!carrier) {
         Template.instance().errors.set('carrier', 'Please select a carrier.');
         errors = true;
       }
 
-      if (!number) {
+      if (!number && number.length === 10) {
         Template.instance().errors.set('number', 'Please enter a valid phone number.');
         errors = true;
       }

--- a/app/imports/ui/components/modals/modal-join-queue/modal-join-queue.js
+++ b/app/imports/ui/components/modals/modal-join-queue/modal-join-queue.js
@@ -253,7 +253,7 @@ Template.ModalJoinQueue.events({
         errors = true;
       }
 
-      if (!number.length === 10) {
+      if (!(number.length === 10)) {
         Template.instance().errors.set('number', 'Please enter a valid phone number.');
         errors = true;
       }


### PR DESCRIPTION
Currently phone number strings are being sent to the server with hyphens and parentheses. This filters the string to accept only digits.