### PR TITLE
Hotfix: filter out undefined tickets when client hasn't subscribed to them

### DIFF
--- a/app/imports/api/queues/helpers.js
+++ b/app/imports/api/queues/helpers.js
@@ -28,8 +28,14 @@ Queues.helpers({
   },
 
   tickets() {
+    // We map ticketIds to tickets rather than use a $in query in order to
+    // preserve order of tickets.
     return this.ticketIds.map((ticketId) => {
       return Tickets.findOne({ _id: ticketId });
+    }).filter((ticket) => {
+      // Filter in case the client has not subscribed to all tickets; this happens
+      // because students aren't allowed access to deleted tickets.
+      return ticket !== undefined;
     });
   },
 


### PR DESCRIPTION
Students are not subscribed to deleted tickets. The previous release broke signups and rendering of tickets when one of the ticket values was `undefined`. This fixes the issue.