### PR TITLE
Update Meteor and packages, fix ticket loading performance

### DIFF
--- a/app/imports/api/queues/helpers.js
+++ b/app/imports/api/queues/helpers.js
@@ -28,20 +28,13 @@ Queues.helpers({
   },
 
   tickets() {
-    // We map ticketIds to tickets rather than use a $in query in order to
-    // preserve order of tickets.
-    return this.ticketIds.map((ticketId) => {
-      return Tickets.findOne({ _id: ticketId });
-    }).filter((ticket) => {
-      // Filter in case the client has not subscribed to all tickets; this happens
-      // because students aren't allowed access to deleted tickets.
-      return ticket !== undefined;
-    });
+    return Tickets.find({ _id: { $in: this.ticketIds } });
   },
 
   activeTickets() {
-    return this.tickets().filter((ticket) => {
-      return ticket.isActive();
+    return Tickets.find({
+      _id: { $in: this.ticketIds },
+      status: { $in: ['open', 'claimed', 'markAsMissing'] },
     });
   },
 
@@ -52,7 +45,7 @@ Queues.helpers({
   },
 
   hasActiveTicketWithUsers(userIds) {
-    const activeTickets = this.activeTickets();
+    const activeTickets = this.activeTickets().fetch();
     return activeTickets.some((ticket) => {
       return _.intersection(ticket.studentIds, userIds).length > 0;
     });

--- a/app/imports/lib/both/signup-gap.js
+++ b/app/imports/lib/both/signup-gap.js
@@ -7,7 +7,7 @@ export class SignupGap {
     }
 
     // Get user's last ticket that was marked as done
-    const userTickets = queue.tickets().filter((ticket) => {
+    const userTickets = queue.tickets().fetch().filter((ticket) => {
       return ticket.status === 'markedAsDone' && ticket.studentIds.indexOf(userId) !== -1;
     });
 

--- a/app/imports/ui/components/queue-card/queue-card.js
+++ b/app/imports/ui/components/queue-card/queue-card.js
@@ -17,7 +17,7 @@ export function svgPatternUrl(queue) {
 }
 
 export function ticketCount(queue) {
-  const activeTicketsCount = queue.activeTickets().length;
+  const activeTicketsCount = queue.activeTickets().count();
   return `${activeTicketsCount} ticket${activeTicketsCount !== 1 ? 's' : ''}`;
 }
 

--- a/app/imports/ui/components/queue-table/queue-table.js
+++ b/app/imports/ui/components/queue-table/queue-table.js
@@ -6,21 +6,29 @@ import './queue-table.html';
 
 Template.QueueTable.helpers({
   noActiveTickets(queue) {
-    return queue.activeTickets().length === 0;
+    return queue.activeTickets().count() === 0;
   },
 
   rows(queue) {
-    let index = 1;
     const rows = [];
 
-    queue.tickets().forEach((ticket) => {
-      if (ticket.isActive()) {
-        ticket.index = index; // eslint-disable-line no-param-reassign
+    const tickets = queue.tickets().fetch();
+    const ticketsById = {};
+    tickets.forEach((ticket) => {
+      ticketsById[ticket._id] = ticket;
+    });
+
+    let index = 1;
+    queue.ticketIds.forEach((ticketId) => {
+      const ticket = ticketsById[ticketId];
+
+      if (ticket && ticket.isActive()) {
+        ticket.index = index;
         rows.push(ticket);
         index += 1;
       }
 
-      if (queue.isCutoff() && (ticket._id === queue.cutoffAfter)) {
+      if (queue.isCutoff() && (ticketId === queue.cutoffAfter)) {
         rows.push({
           isCutoffMarker: true,
         });

--- a/app/imports/ui/pages/queue/queue.html
+++ b/app/imports/ui/pages/queue/queue.html
@@ -11,6 +11,10 @@
 
       {{> QueueActions queue=queue taView=taView}}
       {{> QueueTable queue=queue taView=taView}}
+    {{else}}
+      <div class="row flex-items-xs-center mt-3" style="text-align: center;">
+        <p>Loading...</p>
+      </div>
     {{/if}}
   </div>
 

--- a/app/imports/ui/pages/queue/queue.js
+++ b/app/imports/ui/pages/queue/queue.js
@@ -36,7 +36,7 @@ Template.Queue.onRendered(function onRendered() {
   this.autorun(() => {
     if (this.subscriptionsReady()) {
       const queue = this.getQueue();
-      document.title = `(${queue.activeTickets().length}) ${queue.course().name} · ${queue.name} · SignMeUp`; // eslint-disable-line max-len
+      document.title = `(${queue.activeTickets().count()}) ${queue.course().name} · ${queue.name} · SignMeUp`; // eslint-disable-line max-len
     }
   });
 });

--- a/app/imports/ui/pages/settings/settings.html
+++ b/app/imports/ui/pages/settings/settings.html
@@ -54,6 +54,10 @@
           </div>
         </div>
       {{/if}}
+    {{else}}
+      <div class="row flex-items-xs-center mt-3" style="text-align: center;">
+        <p>Loading...</p>
+      </div>
     {{/if}}
   </div>
 </template>


### PR DESCRIPTION
Updates Meteor and various packages to latest compatible versions.

Reverts queue helpers, specifically `Queues.tickets()`, to only make one database query. This should improve ticket loading performance and consequently time to render. In order to show tickets in the shuffled order, we do the ordering at render time.