### PR TITLE
Release 3.1.2: update CONTRIBUTING.md, fix Bootstrap regression

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,0 @@
-engines:
-  eslint:
-    enabled: true
-    channel: "eslint-3"

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules/
 *.pem
 
 settings.json
+.env

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,6 +1,6 @@
 eslint:
   enabled: true
-  config_file: .eslintrc.json
+  config_file: app/.eslintrc.json
 
 jshint:
   enabled: false

--- a/app/.hound.yml
+++ b/app/.hound.yml
@@ -1,0 +1,9 @@
+eslint:
+  enabled: true
+  config_file: .eslintrc.json
+
+jshint:
+  enabled: false
+
+scss:
+  enabled: false

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "autoprefixer": "^6.4.1",
     "babel-runtime": "^6.18.0",
     "bcrypt": "^0.8.7",
-    "bootstrap": "^4.0.0-alpha.3",
+    "bootstrap": "4.0.0-alpha.5",
     "bootstrap-datepicker": "^1.6.4",
     "filesaver": "0.0.13",
     "geopattern": "^1.2.3",


### PR DESCRIPTION
- Updates CONTRIBUTING.md to have latest instructions, including setting up NGINX locally and using Meteor Toys.
- Pins Bootstrap dependency to v4.alpha.5 to prevent regressions from alpha.6. We'll actually fix the code in a future release.