### PR TITLE
Fix #172: Center-align footer contents on mobile devices

### DIFF
--- a/imports/ui/components/footer/footer.html
+++ b/imports/ui/components/footer/footer.html
@@ -1,8 +1,7 @@
 <template name="Footer">
   <footer class="footer navbar navbar-light pt-2 pb-2">
     <div class="container">
-
-      <ul class="nav navbar-nav float-xs-left">
+      <ul class="nav navbar-nav float-lg-left float-md-left float-sm-left">
         <li class="nav-item">
           <span class="nav-link nav-link-static disabled">
             SignMeUp {{version}}
@@ -14,13 +13,13 @@
             src="https://ghbtns.com/github-btn.html?user=signmeup&repo=signmeup&type=star&count=true"
             frameborder="0"
             scrolling="0"
-            width="160px"
+            width="80px"
             height="20px">
           </iframe>
         </li>
       </ul>
 
-      <ul class="nav navbar-nav float-xs-right">
+      <ul class="nav navbar-nav float-lg-right float-md-right float-sm-right">
         <li class="nav-item">
           <a class="nav-link" href="https://github.com/signmeup/signmeup/wiki">About</a>
         </li>

--- a/imports/ui/components/footer/footer.scss
+++ b/imports/ui/components/footer/footer.scss
@@ -1,7 +1,18 @@
 .footer {
   border-top: 1px solid $gray-lighter;
 }
-
+.container {
+    text-align: center;
+}
+.nav.navbar-nav {
+    text-align: center;
+    display: inline-block;
+    float: none;
+}
+.nav.navbar-nav.nav-item {
+    display: inline-block;
+    float:none;
+}
 .github-button {
-  margin-top: 0.55rem;
+    margin-top: 0.55rem;
 }


### PR DESCRIPTION
I added some properties in footer.scss to make class nav nav-bar align their content in the center. To ensure those properties only applying on mobile screen I force setting float of two ul to left and right on large, medium and small screen. This can basically fix #172. Please give some suggestions on it as I'm not familiar with css operations.