### PR TITLE
Fix erroneous 404 redirect

### DIFF
--- a/imports/ui/pages/queue/queue.js
+++ b/imports/ui/pages/queue/queue.js
@@ -28,8 +28,6 @@ Template.Queue.onCreated(function onCreated() {
     if (queue) {
       this.subscribe('courses.byId', queue.courseId);
       this.subscribe('tickets.byQueueId', queue._id);
-    } else {
-      FlowRouter.go('/404');
     }
   });
 });
@@ -38,6 +36,10 @@ Template.Queue.onRendered(function onRendered() {
   this.autorun(() => {
     if (this.subscriptionsReady()) {
       const queue = this.getQueue();
+      if (!queue) {
+        FlowRouter.go('/404');
+        return;
+      }
       document.title = `(${queue.activeTickets().count()}) ${queue.course().name} · ${queue.name} · SignMeUp`; // eslint-disable-line max-len
     }
   });


### PR DESCRIPTION
I was experiencing a 404 redirect when loading any queue page, regardless of whether or not it actually existed. I experienced this on both Chrome and Safari on macOS. This change moves the redirection code so users are only redirected to the 404 page if the queue actually does not exist.