### PR TITLE
Fix #236: Don't subscribe to user ids before showing notifications

### DIFF
--- a/imports/ui/pages/queue/queue.js
+++ b/imports/ui/pages/queue/queue.js
@@ -69,15 +69,9 @@ Template.Queue.onRendered(function onRendered() {
             // When we first call observe, this function is called for each
             // existing ticket. This "hack" ignores this initial call.
             if (initial) return;
-            const subscription = this.subscribe('users.byIds', ticket.studentIds, () => {
-              const students = ticket.students().fetch();
-              const names = students.map((student) => { return student.fullName(); });
-              const verb = names.length === 1 ? 'has' : 'have';
-              WebNotifications.send(`${names.join(', ')} ${verb} joined the queue`, {
-                body: ticket.question,
-                timeout: 5000,
-              });
-              subscription.stop();
+            WebNotifications.send('A student has joined the queue', {
+              body: ticket.question,
+              timeout: 5000,
             });
           },
         });


### PR DESCRIPTION
This has the drawback of removing student names from the notification but is overall a definite improvement. In order to get the student names back while avoiding this issue I think we would have to replace the now-removed subscription with a server call or something.