### PR TITLE
Display Google profile pictures for TAs

### DIFF
--- a/imports/api/users/helpers.js
+++ b/imports/api/users/helpers.js
@@ -63,4 +63,8 @@ Meteor.users.helpers({
   isTAOrAbove() {
     return this.courses().count() > 0;
   },
+
+  profilePictureUrl() {
+    return this.services && this.services.google && this.services.google.picture;
+  },
 });

--- a/imports/ui/components/profile-pic/profile-pic.html
+++ b/imports/ui/components/profile-pic/profile-pic.html
@@ -2,6 +2,10 @@
   <div
     class="profile-pic {{#if user.status.online}}online{{/if}} {{#if user.status.idle}}idle{{/if}}"
     data-toggle="tooltip" data-placement="bottom" title="{{user.fullName}}">
-    {{user.initials}}
+    {{#if user.profilePictureUrl}}
+      <img src={{user.profilePictureUrl}} />
+    {{else}}
+      <span class="initials">{{user.initials}}</span>
+    {{/if}}
   </div>
 </template>

--- a/imports/ui/components/profile-pic/profile-pic.scss
+++ b/imports/ui/components/profile-pic/profile-pic.scss
@@ -5,7 +5,8 @@
   vertical-align: text-bottom;
 
   margin-left: 4px;
-  padding: 4px 6px 8px 6px;
+  width: 42px;
+  height: 42px;
 
   background-color: white;
   border: 1px solid $gray-200;
@@ -36,5 +37,16 @@
     &::after {
       background-color: theme-color("warning");
     }
+  }
+
+  img {
+    width: 100%;
+  }
+
+  .initials {
+    display: inline-block;
+    width: 100%;
+    line-height: 32px;
+    text-align: center;
   }
 }


### PR DESCRIPTION
Here's what it looks like: ![https://i.imgur.com/7gx6C5d.png](https://i.imgur.com/7gx6C5d.png).
This also normalizes the TA "profile picture" to be 42x42px in all cases.

Note: this has not been tested on Google accounts without profile pictures, but it should just fall back to their initials.