### PR TITLE
Display how long a student has been marked as missing

### DIFF
--- a/imports/api/courses/courses.js
+++ b/imports/api/courses/courses.js
@@ -5,6 +5,7 @@ export const Courses = new Mongo.Collection("courses");
 
 export const SettingsSchema = new SimpleSchema({
   signupGap: { type: Number, defaultValue: 0 },
+  missingWindow: { type: Number, defaultValue: 0 },
   restrictSessionsByDefault: { type: Boolean, defaultValue: false },
   notifications: { type: Object, defaultValue: {} },
   "notifications.allowEmail": { type: Boolean, defaultValue: true },

--- a/imports/api/tickets/tickets.js
+++ b/imports/api/tickets/tickets.js
@@ -50,6 +50,7 @@ Tickets.schema = new SimpleSchema({
     regEx: SimpleSchema.RegEx.Id,
     optional: true
   },
+  missingJobId: { type: String, optional: true },
 
   markedAsDoneAt: { type: Date, optional: true },
   markedAsDoneBy: {

--- a/imports/ui/components/settings-courses/courses-general/courses-general.html
+++ b/imports/ui/components/settings-courses/courses-general/courses-general.html
@@ -65,7 +65,7 @@
             </label>
             <div class="col-3">
               <select class="form-control mt-1" name="missingWindow" id="missing-window">
-                <option value="-1" selected="{{isCurrentMissingWindow course 0}}">No window</option>
+                <option value="-1" selected="{{isCurrentMissingWindow course 0}}">No deletion</option>
                 <option value="15" selected="{{isCurrentMissingWindow course 15}}">15 minutes</option>
                 <option value="30" selected="{{isCurrentMissingWindow course 30}}">30 minutes</option>
                 <option value="45" selected="{{isCurrentMissingWindow course 45}}">45 minutes</option>

--- a/imports/ui/components/settings-courses/courses-general/courses-general.html
+++ b/imports/ui/components/settings-courses/courses-general/courses-general.html
@@ -58,6 +58,24 @@
         </div>
 
         <div class="card-body">
+          <div class="form-group row mb-0">
+            <label for="missing-window" class="col-9 col-form-label">
+              <span>Missing Window</span><br>
+              <span>Time after which a ticket marked as missing is automatically deleted.</span>
+            </label>
+            <div class="col-3">
+              <select class="form-control mt-1" name="missingWindow" id="missing-window">
+                <option value="-1" selected="{{isCurrentMissingWindow course 0}}">No window</option>
+                <option value="15" selected="{{isCurrentMissingWindow course 15}}">15 minutes</option>
+                <option value="30" selected="{{isCurrentMissingWindow course 30}}">30 minutes</option>
+                <option value="45" selected="{{isCurrentMissingWindow course 45}}">45 minutes</option>
+                <option value="60" selected="{{isCurrentMissingWindow course 60}}">1 hour</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="card-body">
           <div class="form-group">
             <label for="signup-gap" class="col-form-label">
               <span class="text-muted">Notifications</span><br>

--- a/imports/ui/components/settings-courses/courses-general/courses-general.js
+++ b/imports/ui/components/settings-courses/courses-general/courses-general.js
@@ -8,6 +8,9 @@ import "./courses-general.html";
 Template.CoursesGeneral.helpers({
   isCurrentSignupGap(course, signupGap) {
     return course.settings.signupGap === signupGap;
+  },
+  isCurrentMissingWindow(course, missingWindow) {
+    return course.settings.missingWindow === missingWindow;
   }
 });
 
@@ -37,6 +40,7 @@ Template.CoursesGeneral.events({
       courseId: this.course._id,
       settings: {
         signupGap: parseInt(event.target.signupGap.value),
+        missingWindow: parseInt(event.target.missingWindow.value),
         restrictSessionsByDefault:
           event.target.restrictSessionsByDefault.checked,
         notifications: {

--- a/imports/ui/components/ticket/ticket-drawer/ticket-drawer.html
+++ b/imports/ui/components/ticket/ticket-drawer/ticket-drawer.html
@@ -6,6 +6,9 @@
           {{#if ticket.isClaimed}}
             {{formattedClaimDuration}}
           {{/if}}
+          {{#if ticket.isMarkedAsMissing}}
+            {{formattedMissingDuration}}
+          {{/if}}
         </div>
         <div class="td col-10 col-md-11">
           <h5 class="mb-2">Question</h5>

--- a/imports/ui/components/ticket/ticket-drawer/ticket-drawer.js
+++ b/imports/ui/components/ticket/ticket-drawer/ticket-drawer.js
@@ -29,7 +29,9 @@ Template.TicketDrawer.onCreated(function onCreated() {
 
     if (ticket && ticket.isMarkedAsMissing()) {
       self.missingDurationInterval = Meteor.setInterval(() => {
-        self.missingDuration.set(moment().diff(moment(ticket.markedAsMissingAt)));
+        self.missingDuration.set(
+          moment().diff(moment(ticket.markedAsMissingAt))
+        );
       }, 1000);
     }
   });

--- a/imports/ui/components/ticket/ticket-drawer/ticket-drawer.js
+++ b/imports/ui/components/ticket/ticket-drawer/ticket-drawer.js
@@ -9,6 +9,7 @@ import "./ticket-drawer.html";
 Template.TicketDrawer.onCreated(function onCreated() {
   const self = this;
   self.claimDuration = new ReactiveVar(0);
+  self.missingDuration = new ReactiveVar(0);
 
   self.autorun(() => {
     const ticket = Template.currentData().ticket;
@@ -21,8 +22,22 @@ Template.TicketDrawer.onCreated(function onCreated() {
         self.claimDuration.set(moment().diff(moment(ticket.claimedAt)));
       }, 1000);
     }
+
+    if (self.missingDurationInterval) {
+      Meteor.clearInterval(self.missingDurationInterval);
+    }
+
+    if (ticket && ticket.isMarkedAsMissing()) {
+      self.missingDurationInterval = Meteor.setInterval(() => {
+        self.missingDuration.set(moment().diff(moment(ticket.markedAsMissingAt)));
+      }, 1000);
+    }
   });
 });
+
+function prefixZero(num) {
+  return num < 10 ? `0${num}` : `${num}`;
+}
 
 Template.TicketDrawer.helpers({
   formattedClaimDuration() {
@@ -30,9 +45,13 @@ Template.TicketDrawer.helpers({
     const seconds = duration.seconds();
     const minutes = duration.minutes();
 
-    function prefixZero(num) {
-      return num < 10 ? `0${num}` : `${num}`;
-    }
+    return `${prefixZero(minutes)}:${prefixZero(seconds)}`;
+  },
+
+  formattedMissingDuration() {
+    const duration = moment.duration(Template.instance().missingDuration.get());
+    const seconds = duration.seconds();
+    const minutes = duration.minutes();
 
     return `${prefixZero(minutes)}:${prefixZero(seconds)}`;
   }


### PR DESCRIPTION
This PR adds a timer to display how long a ticket has been marked as missing. It's more or less identical to the code for displaying a claimed timer, but based on the `markedAsMissingAt` field of a `Ticket`. 

This is something that would be really helpful for CS33 hours. We frequently have many missing students because of long queues, and it would be much easier to enforce our missing policy with a timer.