### PR TITLE
Update fourseven:scss to resolve compatibility issues

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -19,7 +19,7 @@ ejson@1.1.0
 spacebars@1.0.12
 check@1.3.1
 accounts-password@1.5.1
-fourseven:scss
+fourseven:scss@4.5.4
 reactive-var@1.0.11
 email@1.2.3
 kadira:debug

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -40,7 +40,7 @@ ecmascript-runtime-server@0.7.1
 ejson@1.1.0
 email@1.2.3
 es5-shim@4.8.0
-fourseven:scss@3.13.0
+fourseven:scss@4.5.4
 geojson-utils@1.0.10
 google-oauth@1.2.5
 hot-code-push@1.0.4


### PR DESCRIPTION
We currently use Meteor 1.6.1, which when installed by following the instructions in [CONTRIBUTING.md](https://github.com/signmeup/signmeup/blob/master/.github/CONTRIBUTING.md) uses Node.js v8, which is incompatible with node-sass v3.13.0 (and subsequently fourseven:scss v3.13.0) according to [this](https://github.com/sass/node-sass/releases?after=2331) and [this](https://github.com/Meteor-Community-Packages/meteor-scss).

I upgraded fourseven:scss to v4.5.4, which should resolve all issues for now. CONTRIBUTING.md should probably be updated too later on to avoid similar issues when dependencies change in the future.

I would appreciate it if someone else could pull this and make sure it runs in their dev environment. The change is low risk and should not change much apart from resolving the issues mentioned above.