### PR TITLE
Improve queue page title for students

### DIFF
--- a/imports/ui/pages/queue/queue.js
+++ b/imports/ui/pages/queue/queue.js
@@ -86,7 +86,7 @@ Template.Queue.onRendered(function onRendered() {
 
         let prefix =
           studentTicketIndex === -1
-            ? ""
+            ? `(${queue.activeTickets().count()}) `
             : studentTicketIndex === 0
               ? "(you’re next) "
               : `(${studentTicketIndex} ahead) `;

--- a/imports/ui/pages/queue/queue.js
+++ b/imports/ui/pages/queue/queue.js
@@ -73,27 +73,23 @@ Template.Queue.onRendered(function onRendered() {
         return;
       }
 
-      if (isTA()) {
-        document.title = `(${queue.activeTickets().count()}) ${
-          queue.course().name
-        } · ${queue.name} · SignMeUp`;
-      } else {
-        const studentTicketIndex = queue
-          .tickets()
-          .fetch()
-          .filter(t => t.status === "open")
-          .findIndex(t => t.belongsToUser(Meteor.userId()));
+      const studentTicketIndex = queue
+        .tickets()
+        .fetch()
+        .filter(t => t.status === "open")
+        .findIndex(t => t.belongsToUser(Meteor.userId()));
 
-        let prefix =
-          studentTicketIndex === -1
-            ? `(${queue.activeTickets().count()}) `
-            : studentTicketIndex === 0
-              ? "(you’re next) "
-              : `(${studentTicketIndex} ahead) `;
-        document.title = `${prefix}${queue.course().name} · ${
-          queue.name
-        } · SignMeUp`;
+      let prefix;
+      if (studentTicketIndex === -1) {
+        prefix = queue.activeTickets().count();
+      } else if (studentTicketIndex === 0) {
+        prefix = "you’re next";
+      } else {
+        prefix = `${studentTicketIndex} ahead`;
       }
+      document.title = `(${prefix}) ${queue.course().name} · ${
+        queue.name
+      } · SignMeUp`;
 
       // setup notifications
       if (isTA()) {

--- a/imports/ui/pages/queue/queue.js
+++ b/imports/ui/pages/queue/queue.js
@@ -72,9 +72,28 @@ Template.Queue.onRendered(function onRendered() {
         FlowRouter.go("/404");
         return;
       }
-      document.title = `(${queue.activeTickets().count()}) ${
-        queue.course().name
-      } · ${queue.name} · SignMeUp`; // eslint-disable-line max-len
+
+      if (isTA()) {
+        document.title = `(${queue.activeTickets().count()}) ${
+          queue.course().name
+        } · ${queue.name} · SignMeUp`;
+      } else {
+        const studentTicketIndex = queue
+          .tickets()
+          .fetch()
+          .filter(t => t.status === "open")
+          .findIndex(t => t.belongsToUser(Meteor.userId()));
+
+        let prefix =
+          studentTicketIndex === -1
+            ? ""
+            : studentTicketIndex === 0
+              ? "(you’re next) "
+              : `(${studentTicketIndex} ahead) `;
+        document.title = `${prefix}${queue.course().name} · ${
+          queue.name
+        } · SignMeUp`;
+      }
 
       // setup notifications
       if (isTA()) {


### PR DESCRIPTION
Currently, the queue page shows the total number of tickets in the queue for both TAs and students. While useful for TAs who are there to help all the students, the most pressing concern for a typical student — like me! — is “when will the TA help *me*?” This PR attempts to answer this question for students by showing them the number of tickets that are in line ahead of them, and hiding the number icon when the student doesn’t have any tickets waiting so they aren’t distracted while working.

This is my first time contributing to either this project or a Meteor project in general, so any feedback would be appreciated.